### PR TITLE
fix: deployment indent

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,7 +3,7 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: 1.10.4
 dependencies:
 - name: common

--- a/charts/mailpit/templates/deployment.yaml
+++ b/charts/mailpit/templates/deployment.yaml
@@ -86,10 +86,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- with .Values.args }}
-          {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 10 }}
           {{- end }}
           {{- with .Values.extraEnvVars }}
-          env: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+          env: {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 10 }}
           {{- end }}
           {{- with .Values.resources }}
           resources: {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
When using fluxcd, an incorrect indent can cause issues with the `Values.args` in a helm release. 
Helm template:
```
          args:
          - --db-file
          - /var/lib/mailpit/mailpit.db
          - --webroot
          - /
            - --tag
            - tag=some-tag
```
becomes
```
          args:
          - --db-file
          - /var/lib/mailpit/mailpit.db
          - --webroot
          - / - --tag - tag=some-tag
```