### PR TITLE
aknowledge webroot for health-checks

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,7 +3,7 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: 1.12.1
 dependencies:
 - name: common

--- a/charts/mailpit/templates/deployment.yaml
+++ b/charts/mailpit/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /livez
+              path: {{ .Values.mailpit.webroot }}livez
               port: 8025
               scheme: HTTP
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -114,7 +114,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: {{ .Values.mailpit.webroot }}readyz
               port: 8025
               scheme: HTTP
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
Fixes #37 

Fix uses the same logic as the corresponding [application](https://github.com/axllent/mailpit/blob/5271f5226bcf439dc1c03baf0f755dced6062537/server/server.go#L53)