### PR TITLE
Expand deployment security context configurability

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,7 +3,7 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.15.3
+version: 0.15.4
 appVersion: 1.15.1
 dependencies:
 - name: common

--- a/charts/mailpit/templates/deployment.yaml
+++ b/charts/mailpit/templates/deployment.yaml
@@ -42,11 +42,7 @@ spec:
           image: {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 1001
-            runAsGroup: 1001
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           args:
           - --db-file
           - /var/lib/mailpit/mailpit.db

--- a/charts/mailpit/values.schema.json
+++ b/charts/mailpit/values.schema.json
@@ -74,6 +74,9 @@
                 }
             }
         },
+        "podSecurityContext": {
+            "type": "object"
+        },
         "replicaCount": {
             "type": "number",
             "description": "Number of replicas to deploy",

--- a/charts/mailpit/values.yaml
+++ b/charts/mailpit/values.yaml
@@ -73,6 +73,16 @@ updateStrategy:
   ##
   type: RollingUpdate
 
+## @param podSecurityContext.type [object] SecurityContext for pods
+## ref: https://kubernetes.io/docs/concepts/security/pod-security-standards/
+##
+podSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsUser: 1001
+  runAsGroup: 1001
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+
 ## @param replicaCount Number of replicas to deploy
 ##
 replicaCount: 1


### PR DESCRIPTION
Adds the option to configure the pod's security context using the values.yaml.

I ran into the issue that I could not add additional values to the pod's security context. So I've moved them into values.yaml