### PR TITLE
[MailPit] include -http suffix of service in extraHosts

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,7 +3,7 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.17.2
+version: 0.17.3
 appVersion: 1.17.2
 dependencies:
 - name: common

--- a/charts/mailpit/templates/ingress.yaml
+++ b/charts/mailpit/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default $.Values.ingress.pathType .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-http" (include "common.names.fullname" .)) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.ingress.tls (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations ))) .Values.ingress.extraTls }}
   tls:


### PR DESCRIPTION
Hi there,

when trying to use the ingress setting "extraHosts" which is provided by the bitnami parent chart, the service will be wrongly named as it lacks the suffix -http.

This will be fixed with this update.

Best regards
Florian