### PR TITLE
feat: add revisionHistoryLimit to mailpit chart

### DIFF
--- a/charts/mailpit/templates/deployment.yaml
+++ b/charts/mailpit/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- if and .Values.persistence.enabled (eq (index .Values.persistence.accessModes 0) "ReadWriteOnce") }}
   strategy:
     type: Recreate

--- a/charts/mailpit/values.yaml
+++ b/charts/mailpit/values.yaml
@@ -100,6 +100,10 @@ containerSecurityContext:
 ##
 replicaCount: 1
 
+## @param revisionHistoryLimit The number of old history to retain to allow rollback
+##
+revisionHistoryLimit: 10
+
 ## resource requests and limits
 ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 ## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).


### PR DESCRIPTION
Allow setting revisionHistoryLimit to mailpit chart.
Chart's default value matches the kubernetes default value, making this change transparent.
Thanks! 