### PR TITLE
Allow enableServiceLinks customization for mailpit

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,7 +3,7 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.23.1
+version: 0.23.2
 appVersion: 1.23.1
 dependencies:
 - name: common

--- a/charts/mailpit/templates/deployment.yaml
+++ b/charts/mailpit/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}

--- a/charts/mailpit/values.schema.json
+++ b/charts/mailpit/values.schema.json
@@ -147,6 +147,11 @@
             "default": [],
             "items": {}
         },
+        "enableServiceLinks": {
+            "type": "boolean",
+            "description": "enableServiceLinks enabled by default https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26",
+            "default": true
+        },
         "mailpit": {
             "type": "object",
             "properties": {

--- a/charts/mailpit/values.yaml
+++ b/charts/mailpit/values.yaml
@@ -167,6 +167,9 @@ nodeSelector: {}
 ##     effect: NoSchedule
 tolerations: []
 
+## @param enableServiceLinks enabled by default https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26
+enableServiceLinks: true
+
 # https://github.com/axllent/mailpit/wiki/Basic-authentication
 # https://github.com/axllent/mailpit/wiki/HTTPS
 mailpit:


### PR DESCRIPTION
**Motivation:**
`enableServiceLinks` is enabled in Kubernetes by default: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/. However, this might not be desirable, i.e., would add unnecessary environment variables in the pod or affect startup performance in large namespaces with many services.

**Changes proposed:**
- Allow `enableServiceLinks` customization for mailpit, keep it enabled by default as it has been before.