### PR TITLE
Bump mailpit to 1.25.0. Allow multiline htpasswd in secrets

### DIFF
--- a/charts/mailpit/Chart.yaml
+++ b/charts/mailpit/Chart.yaml
@@ -3,8 +3,8 @@ name: mailpit
 description: An email and SMTP testing tool with API for developers
 icon: https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/mailpit.svg
 type: application
-version: 0.24.0
-appVersion: 1.24.0
+version: 0.25.0
+appVersion: 1.25.0
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/mailpit/templates/secret.yaml
+++ b/charts/mailpit/templates/secret.yaml
@@ -11,10 +11,12 @@ metadata:
 type: Opaque
 stringData:
   {{- if and .Values.mailpit.ui.authFile.enabled (not .Values.mailpit.ui.authFile.existingSecret) }}
-  ui.htpasswd: {{ .Values.mailpit.ui.authFile.htpasswd }}
+  ui.htpasswd: 
+    {{ .Values.mailpit.ui.authFile.htpasswd | indent 4 | trim }}
   {{- end }}
   {{- if and .Values.mailpit.smtp.authFile.enabled (not .Values.mailpit.smtp.authFile.existingSecret) }}
-  smtp.htpasswd: {{ .Values.mailpit.smtp.authFile.htpasswd }}
+  smtp.htpasswd: 
+    {{ .Values.mailpit.smtp.authFile.htpasswd | indent 4 | trim }}
   {{- end }}
   {{- with .Values.mailpit.relay.config }}
   smtp_relay.yaml: |

--- a/charts/mailpit/values.yaml
+++ b/charts/mailpit/values.yaml
@@ -34,7 +34,7 @@ global:
 image:
   registry: docker.io
   repository: axllent/mailpit
-  tag: v1.24.0
+  tag: v1.25.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Hi @jouve.

Bumped Mailpit to V1.25.0. Tested on EKS and found no errors.

Fixed an issue I was having with multiline htpasswd entries in secrets. Before the fix it did not want to consume anything that had more than 1 line. The following config would be inteprited as faulty:

```
mailpit:
  ui:
    authFile:
      enabled: true
      htpasswd: |
        test:$apr1$FY/whCqzdkkfdmfew
        test2:$apr1$FY/whCqzdkkfdmfew
```

```
Error: YAML parse error on mailpit/templates/secret.yaml: error converting YAML to JSON: yaml: line 20: could not find expected ':'
```

The fix allows for multiline htpasswd  to be passed into config. Tested with Hashicorp Vault and a plain text config.

If you have any questions or proposals I would gladly discuss them