### PR TITLE
add support for extraObjects to allow dynamic manifests via values

### DIFF
--- a/charts/mailpit/templates/extra-list.yaml
+++ b/charts/mailpit/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/mailpit/templates/extra-manifest.yaml
+++ b/charts/mailpit/templates/extra-manifest.yaml
@@ -1,8 +1,0 @@
-{{ range .Values.extraObjects }}
----
-{{- if typeIs "string" . }}
-{{ tpl . $ }}
-{{ else }}
-{{ tpl (. | toYaml) $ }}
-{{- end }}
-{{ end }}

--- a/charts/mailpit/values.yaml
+++ b/charts/mailpit/values.yaml
@@ -380,10 +380,10 @@ persistence:
   ##
   volumeName: ""
 
-## extraObjects could be utilized to add dynamic manifests via values
-extraObjects: []
+## extraDeploy could be utilized to add dynamic manifests via values
+extraDeploy: []
 # Examples:
-# extraObjects:
+# extraDeploy:
 # - apiVersion: networking.istio.io/v1alpha3
 #   kind: VirtualService
 #   metadata:


### PR DESCRIPTION
## Summary

This PR introduces support for `extraObjects` in the Helm chart, enabling users to inject additional Kubernetes manifests dynamically via `values.yaml`.

In my specific use case, this was needed to create an Istio `VirtualService` to expose and access the Mailpit UI. Instead of modifying the chart or maintaining a fork, `extraObjects` allows defining this resource directly in the values file in a clean and reusable way.

The implementation supports both raw YAML and structured objects, and leverages `tpl` so values can include Helm templating when needed.

This approach keeps the chart generic while allowing easy customization and extension without changing its core templates.