### PR TITLE
fix: conditional volume mounting when persistence=false; correct config.yml file path in deployment

### DIFF
--- a/charts/distribution/Chart.yaml
+++ b/charts/distribution/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: distribution
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
-appVersion: 3.1.0
+version: 0.2.2
+appVersion: 3.1.1
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/distribution/README.md
+++ b/charts/distribution/README.md
@@ -33,10 +33,10 @@ helm install mailpit jouve/distribution
 ### Distribution parameters
 
 | Name                                              | Description                                                                                                                                | Value                       |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |-----------------------------|
 | `image.registry`                                  | image registry                                                                                                                             | `docker.io`                 |
 | `image.repository`                                | image repository                                                                                                                           | `distribution/distribution` |
-| `image.tag`                                       | image tag (immutable tags are recommended)                                                                                                 | `3.1.0`                     |
+| `image.tag`                                       | image tag (immutable tags are recommended)                                                                                                 | `3.1.1`                     |
 | `image.digest`                                    | image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                        |
 | `image.pullPolicy`                                | image pull policy                                                                                                                          | `IfNotPresent`              |
 | `image.pullSecrets`                               | image pull secrets                                                                                                                         | `[]`                        |

--- a/charts/distribution/templates/deployment.yaml
+++ b/charts/distribution/templates/deployment.yaml
@@ -122,9 +122,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: etc
-              mountPath: /etc/docker/registry
+              mountPath: /etc/distribution
+            {{- if .Values.persistence.enabled }}
             - name: registry
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
             {{- end }}
@@ -135,9 +137,11 @@ spec:
         - name: etc
           configMap:
             name: {{ template "common.names.fullname" . }}
+        {{- if .Values.persistence.enabled }}
         - name: registry
           persistentVolumeClaim:
             claimName: {{ with .Values.persistence.existingClaim }}{{ . }}{{ else }}{{ template "common.names.fullname" . }}{{ end }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Changes

### Bug fixes
- **Conditional volume mounting**: Volume is now mounted only when `persistence.enabled=true`. When using S3 storage, there's no need to enable persistence - previously this incorrectly created a PVC for each distribution replica.

- **Fixed config.yml path**: Updated default configuration file directory from `/etc/docker/registry` (2.x) to `/etc/distribution` (to match 3.x defaults).

## Testing
- [x] `ct lint` passes
- [x] `ct install` passes with S3 storage
- [x] `ct install` passes with filesystem storage